### PR TITLE
use keepalive-socket for cross-platform support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ configparser==5.0.1
 emlx==1.0.0
 darkdetect==0.1.1
 keyring==21.5.0
+keepalive-socket==0.0.1

--- a/src/mailbox_imap.py
+++ b/src/mailbox_imap.py
@@ -21,11 +21,11 @@ import typing
 import collections
 import os.path
 import pickle
+import keepalive
 
 from src.mailbox_message import MailboxCleanerMessage
 
 imaplib._MAXLINE = 10000000  # pylint: disable=protected-access
-TCP_KEEPALIVE = 0x10
 
 __author__ = "Alexander Willner"
 __copyright__ = "Copyright 2020, Alexander Willner"
@@ -79,9 +79,7 @@ class MailboxCleanerIMAP():
 
             self.imap.sock.setsockopt(
                 socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.imap.sock.setsockopt(
-                socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            self.imap.sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE, 3)
+            keepalive.set(self.imap.sock)
             self._load_cache()
         except socket.gaierror as error:
             raise SystemExit('Login failed (wrong server?): %s' %


### PR DESCRIPTION
On Linux, I received a
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/til/git/MailboxCleanup/src/mailbox_cli.py", line 133, in <module>
    main()
  File "/home/til/git/MailboxCleanup/src/mailbox_cli.py", line 102, in main
    imap.login()
  File "/home/til/git/MailboxCleanup/src/mailbox_imap.py", line 84, in login
    self.imap.sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE, 3)
OSError: [Errno 22] Invalid argument
```
So, I looked for a cross-platform solution, found https://stackoverflow.com/a/14855726/119725 and https://stackoverflow.com/a/76668530/119725 and decided to use the latter.

I hope, you find it useful. Thanks for the great project!

PS. Sorry for the PR noise - I used `main` as the source branch before and that is not good...